### PR TITLE
Make sure Slack configs can be passed with Environmental Variablels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,11 @@ buildConfig {
     clsName = 'BuildConfig'
 
     Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    buildConfigField 'String', 'SLACK_TOKEN', properties.getProperty("slackToken", null)
-    buildConfigField 'String', 'SLACK_CHANNEL_NAME', properties.getProperty("slackChannelName", null)
+    File file = project.rootProject.file('local.properties')
+    if (file.exists())
+        properties.load(file.newDataInputStream())
+    buildConfigField 'String', 'SLACK_TOKEN', properties.getProperty("slackToken", "${System.env.SLACK_TOKEN}")
+    buildConfigField 'String', 'SLACK_CHANNEL_NAME', properties.getProperty("slackChannelName", "${System.env.SLACK_CHANNEL_NAME}")
 }
 
 kotlin {


### PR DESCRIPTION
# Issue
N/A

# Content
* To make the project buildable with CircleCI, change build.gradle to read Environmental Variables if there is no local.properties.