### PR TITLE
Read slack configs from env variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.19.3"
     compile "org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT"
+    testCompile("org.junit.jupiter:junit-jupiter-api:5.0.0")
+    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.0.0")
 }
 
 jar {

--- a/src/main/java/jp/co/fablic/spikot/SlackNotifier.kt
+++ b/src/main/java/jp/co/fablic/spikot/SlackNotifier.kt
@@ -1,6 +1,9 @@
 package jp.co.fablic.spikot
 
 import com.github.kittinunf.fuel.Fuel
+import jp.co.fablic.spikot.system.slackChannelName
+import jp.co.fablic.spikot.system.slackToken
+import jp.co.fablic.spikot.system.envVars
 import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.launch
 import java.util.logging.Logger
@@ -8,18 +11,24 @@ import java.util.logging.Logger
 class SlackNotifier {
     private val logger = Logger.getLogger(SlackNotifier::javaClass.name)
     private val url = "https://slack.com/api/chat.postMessage"
+    private val token by lazy {
+        envVars[slackToken]
+    }
+    private val channelName by lazy {
+        envVars[slackChannelName]
+    }
 
     fun postMessage(text: String, color: String? = null) {
         if (color == null) {
             postMessage(listOf(
-                    "token" to BuildConfig.SLACK_TOKEN,
-                    "channel" to BuildConfig.SLACK_CHANNEL_NAME,
+                    "token" to token,
+                    "channel" to channelName,
                     "text" to text
             ))
         } else {
             postMessage(listOf(
-                    "token" to BuildConfig.SLACK_TOKEN,
-                    "channel" to BuildConfig.SLACK_CHANNEL_NAME,
+                    "token" to token,
+                    "channel" to channelName,
                     "attachments" to String.format("[{\"text\": \"%s\", \"color\": \"%s\"}]", text, color)
             ))
         }

--- a/src/main/java/jp/co/fablic/spikot/system/EnvVariables.kt
+++ b/src/main/java/jp/co/fablic/spikot/system/EnvVariables.kt
@@ -1,0 +1,10 @@
+package jp.co.fablic.spikot.system
+
+val envVars = Variables(SystemEnvKeyVals())
+
+val slackToken = StrVar("SLACK_TOKEN")
+val slackChannelName = StrVar("SLACK_CHANNEL_NAME")
+
+private class SystemEnvKeyVals : KeyVals {
+    override fun get(key: String): String? = System.getenv(key)
+}

--- a/src/main/java/jp/co/fablic/spikot/system/Variables.kt
+++ b/src/main/java/jp/co/fablic/spikot/system/Variables.kt
@@ -1,0 +1,23 @@
+package jp.co.fablic.spikot.system
+
+interface KeyVals {
+    operator fun get(key : String) : String?
+}
+
+class Variables(private val keyVals: KeyVals) {
+    operator fun <T> get(v : Var<T>) : T = v.parse(keyVals[v.key])
+}
+
+sealed class Var<out T>(val key : String) {
+    abstract fun parse(v : String?) : T
+}
+
+class StrVar(key : String) : Var<String>(key) {
+    override fun parse(v: String?) = v ?: throw KeyNotFound(key)
+}
+
+class NullableStrVar(key : String) : Var<String?>(key) {
+    override fun parse(v: String?): String? = v
+}
+
+class KeyNotFound(key : String) : Exception("System variable with key [$key] is not set")

--- a/src/test/kotlin/jp/co/fablic/spikot/system/VariablesTest.kt
+++ b/src/test/kotlin/jp/co/fablic/spikot/system/VariablesTest.kt
@@ -1,0 +1,44 @@
+package jp.co.fablic.spikot.system
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+internal class VariablesTest {
+  private val map = MutableKeyVals()
+  private val mapVars = Variables(map)
+
+  @BeforeEach
+  fun clear() = map.clear()
+
+  @Test
+  @DisplayName("StringVar can be read")
+  fun testStringVar() {
+    val key = "SLACK_TOKEN"
+    val myToken = "my-token"
+    map[key] = myToken
+
+    val value = mapVars[StrVar(key)]
+    assertEquals(myToken, value)
+  }
+
+  @Test
+  @DisplayName("Reading a non-existent StringVar throws an exception")
+  fun testStringVarDoesNotExist() {
+    assertThrows(KeyNotFound::class.java, { mapVars[StrVar("nowhere-key")] })
+  }
+
+  @Test
+  @DisplayName("Reading a non-existent NullableStringVar returns null")
+  fun testNullableStringVar() {
+    assertNull(mapVars[NullableStrVar("nowhere-key")])
+  }
+}
+
+private class MutableKeyVals : KeyVals {
+  val map = mutableMapOf<String, String?>()
+  override operator fun get(key: String) = map[key]
+  operator fun set(key: String, value: String?) = map.set(key, value)
+  fun clear() = map.clear()
+}


### PR DESCRIPTION
# Issue
N/A

# Content
* Read Slack configs (token and channel name) from runtime environmental variables instead of BuildConfig