### PR TITLE
Include build info in jar MANIFEST.MF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,11 @@ jobs:
             - ~/.m2
           key: v1-dependencies-{{ checksum "build.gradle" }}
         
-      # run tests!
-      - run: gradle test
+      # build & run tests!
+      - run: gradle build
 
       - store_test_results:
           path: build/test-results/junit-platform
-
-      - run: gradle assemble
 
       - store_artifacts:
           path: build/libs

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
+        classpath 'com.github.ksoichiro:gradle-build-info-plugin:0.2.0'
     }
 }
 
@@ -18,6 +19,7 @@ apply plugin: 'kotlin'
 apply plugin: 'de.fuerstenau.buildconfig'
 apply plugin: 'idea'
 apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'com.github.ksoichiro.build.info'
 
 buildConfig {
     appName = project.name


### PR DESCRIPTION
# Issue
N/A

# Content
* Apply https://github.com/ksoichiro/gradle-build-info-plugin
* Run gradle command only once to avoid MANIFEST.MF is refreshed (See https://github.com/ksoichiro/gradle-build-info-plugin/issues/3)

# How to verify the changes
1. Build the JAR file and run the command to verify build info is included in META-INF/MANIFEST.MF
    ```
    $ unzip -p spikot-0.1.0.jar META-INF/MANIFEST.MF
    Manifest-Version: 1.0
    Git-Branch: put-revision-in-jar
    Build-Date: 2017-11-11 11:39:53 +0900
    Build-Os-Name: Linux
    Build-Java-Vendor: Oracle Corporation
    Build-Os-Version: 4.4.0-97-generic
    Git-Committer-Date: 2017-11-11 10:53:23 +0900
    Git-Commit: d0dc506
    Build-Java-Version: 1.8.0_131
    ```